### PR TITLE
選手の登録・削除機能の追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ bundler_args: --without development --deployment
 notifications:
   email: false
 script:
-  - bundle exec rake db:create
-  - bundle exec rake db:migrate
-  - bundle exec rspec spec
+  - bundle exec rails db:create
+  - bundle exec rails db:migrate
+  - bundle exec rspec

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -22,9 +22,43 @@ class PlayersController < ApplicationController
     end
   end
 
+  def edit
+    if admin_user?
+      @players = find_player_id
+    else
+      flash[:success] = '権限がないためアクセスできません'
+      redirect_to players_path
+    end
+  end
+
+  def update
+    player = find_player_id
+    if player.update(require_player_params)
+      flash[:success] = '更新が完了しました'
+      redirect_to players_path
+    else
+      render :edit
+    end
+
+  end
+
+  def destroy
+    player = find_player_id
+    player.destroy
+    flash[:success] = '削除が完了しました'
+    redirect_to players_path
+  end
 
   private
+  def find_player_id
+    Player.find(params[:id])
+  end
+
   def player_params
-    params.permit(:name, :squad_number, :birthday, :position, :image, :image_cache)
+    params.permit(:name, :squad_number, :position, :image, :image_cache)
+  end
+
+  def require_player_params
+    params.require(:player).permit(:name, :squad_number, :position, :image, :image_cache)
   end
 end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -32,8 +32,8 @@ class PlayersController < ApplicationController
   end
 
   def update
-    player = find_player_id
-    if player.update(require_player_params)
+    @players = find_player_id
+    if @players.update(require_player_params)
       flash[:success] = '更新が完了しました'
       redirect_to players_path
     else

--- a/app/views/players/_form.html.haml
+++ b/app/views/players/_form.html.haml
@@ -1,0 +1,3 @@
+%div.section-input_schedule
+  %div.ml-auto.posts_button.post
+    = link_to '選手一覧に戻る', players_path, title: '選手一覧', class: 'botton'

--- a/app/views/players/edit.html.haml
+++ b/app/views/players/edit.html.haml
@@ -1,9 +1,9 @@
 %dev.d-flex.align-items-center
-  %h1 選手登録
+  %h1 選手登録の編集
 
 = render "form"
 -#TODO: _fromパーシャルでedit/newをまとめる
-= form_with url: @players, local: true do |f|
+= form_with model: @players, local: true do |f|
 
   - if @players.errors.any?
     %div.alert.alert-denger
@@ -37,4 +37,4 @@
     %form-text.text-muted#small.title-tip
       ※選手写真がない場合、ファイル選択は不要です。
 
-  = f.submit '選手を登録する', class: 'btn btn-info btn-block'
+  = f.submit '登録を更新する', class: 'btn btn-info btn-block'

--- a/app/views/players/index.html.haml
+++ b/app/views/players/index.html.haml
@@ -33,6 +33,10 @@
           ポシション：
           = player.position
           %br
+          - if user_signed_in? && current_user.admin?
+            = link_to '編集', edit_player_path(player.id)
+            &frasl;
+            = link_to '削除', player_path(player.id), method: :delete, data: { confirm: "#{player.name}の選手登録を削除しますか？"}
 - else
   %div.non-players
     %strong

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   #TODO: as使いたい
   post "match/schedule_results/:id", to: "match/schedule_results#update"
   resource :match do
-    resources :schedule_results, controller: 'match/schedule_results', only: [:index, :new, :create , :edit, :destroy]
+    resources :schedule_results, controller: 'match/schedule_results', except: [:show]
   end
 
   # contact page
@@ -17,8 +17,7 @@ Rails.application.routes.draw do
   end
 
   # players page
-  resources :players, only: [:index, :new, :create]
-
+  resources :players, except: [:show]
 
   devise_for :users
 

--- a/spec/features/player_spec.rb
+++ b/spec/features/player_spec.rb
@@ -139,4 +139,122 @@ RSpec.feature "/player", js: true do
       end
     end
   end
+
+  describe '登録選手の編集' do
+    context 'adminユーザの場合' do
+      let(:admin_user) { create(:admin_user) }
+
+      before do
+        visit '/users/sign_in'
+        fill_in 'user_email', with: admin_user.email
+        fill_in 'user_password', with: admin_user.password
+        click_on 'ログインする'
+        click_on '選手紹介'
+        click_on '選手を登録する'
+      end
+
+      scenario '登録選手の編集ができること' do
+        expect(page).to have_content '選手登録'
+
+        fill_in 'name', with: playername = Faker::Name.name
+        select '10', from: 'squad_number'
+        select 'MF', from: 'position'
+        attach_file 'image', "#{Rails.root}/spec/factories/images/test_pic.png"
+        click_on '登録する'
+
+        expect(page).to have_content '登録が完了しました'
+        expect(page).to have_content playername
+        expect(page).to have_content 10
+        expect(page).to have_content 'MF'
+        have_css "image[src$='test_pic.png']"
+
+        click_on '編集'
+        expect(page).to have_content '選手登録の編集'
+
+        fill_in 'player_name', with: playername = Faker::Name.name + '新芽'
+        select '15', from: 'player_squad_number'
+        select 'FW', from: 'player_position'
+        attach_file 'player_image', "#{Rails.root}/spec/factories/images/test_pic.png"
+        click_on '登録を更新する'
+
+        expect(page).to have_content '更新が完了しました'
+        expect(page).to have_content playername
+        expect(page).to have_content 15
+        expect(page).to have_content 'FW'
+        have_css "image[src$='test_pic.png']"
+      end
+    end
+
+    context 'adminユーザではない場合' do
+      let(:user) { create(:user) }
+
+      before do
+        visit '/users/sign_in'
+        fill_in 'user_email', with: user.email
+        fill_in 'user_password', with: user.password
+        click_on 'ログインする'
+      end
+
+      scenario '選手登録の編集ができないこと' do
+        click_on '選手紹介'
+
+        expect(page).to have_content 'PLAYERS'
+        expect(page).not_to have_content '編集'
+      end
+    end
+  end
+
+  describe '登録選手の削除' do
+    context 'adminユーザの場合' do
+      let(:admin_user) { create(:admin_user) }
+
+      before do
+        visit '/users/sign_in'
+        fill_in 'user_email', with: admin_user.email
+        fill_in 'user_password', with: admin_user.password
+        click_on 'ログインする'
+        click_on '選手紹介'
+        click_on '選手を登録する'
+      end
+
+      scenario '登録選手の編集ができること' do
+        expect(page).to have_content '選手登録'
+
+        fill_in 'name', with: playername = Faker::Name.name
+        select '10', from: 'squad_number'
+        select 'MF', from: 'position'
+        attach_file 'image', "#{Rails.root}/spec/factories/images/test_pic.png"
+        click_on '登録する'
+
+        expect(page).to have_content '登録が完了しました'
+        expect(page).to have_content playername
+        expect(page).to have_content 10
+        expect(page).to have_content 'MF'
+        have_css "image[src$='test_pic.png']"
+
+        click_on '削除'
+        page.driver.browser.switch_to.alert.accept
+
+        expect(page).to have_content '削除が完了しました'
+      end
+    end
+
+    context 'adminユーザではない場合' do
+      let(:user) { create(:user) }
+
+      before do
+        visit '/users/sign_in'
+        fill_in 'user_email', with: user.email
+        fill_in 'user_password', with: user.password
+        click_on 'ログインする'
+      end
+
+      scenario '選手登録の削除ができないこと' do
+        click_on '選手紹介'
+
+        expect(page).to have_content 'PLAYERS'
+        expect(page).not_to have_content '削除'
+      end
+    end
+  end
 end

--- a/spec/features/player_spec.rb
+++ b/spec/features/player_spec.rb
@@ -217,7 +217,7 @@ RSpec.feature "/player", js: true do
         click_on '選手を登録する'
       end
 
-      scenario '登録選手の編集ができること' do
+      scenario '登録選手の削除ができること' do
         expect(page).to have_content '選手登録'
 
         fill_in 'name', with: playername = Faker::Name.name
@@ -249,7 +249,7 @@ RSpec.feature "/player", js: true do
         click_on 'ログインする'
       end
 
-      scenario '選手登録の削除ができないこと' do
+      scenario '登録選手の削除ができないこと' do
         click_on '選手紹介'
 
         expect(page).to have_content 'PLAYERS'


### PR DESCRIPTION
TODO
・ポジションがnilになるを解消
☑️・生年月日が表示されるようにする
✅・画像表示できるようにする
✅・一覧表示のデザイン修正
✅・並び順を変更する
✅・ホームの画像がづれた


✅・デフォルト画像をリライズされた状態で表示する（選択なかったら）
　✅・デフォルト画像の大きさを統一する
✅・class名の修正
✅・登録フォームにサムネの画像入れる
✅・バリデーション
　✅・nameの文字設定もする(11文字くらい)
・テスト追加
　✅・投稿機能はadminのみ
　✅・adminじゃない場合
✅・herokuデプロイ
　✅・STG確認

□ブランチ切る
　✅・編集画面作成
　✅・編集画面のバリデーション
　✅・削除機能
　✅・テスト追加
　　✅・機能はadminのみ

✅・herokuで編集画面から写真の更新ができない